### PR TITLE
ECB-3: Export attribute with active locales only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.3 (2015-10-28)
+## Bug fixes
+ECB-3: Attribute labels are tranlated and exported to PimGento only for active locales
+ECB-4: Add missing translations on enhanced product export display
+
 # 1.0.2 (2015-10-12)
 ## Bug fix
 - Correct a bug that prevents family export to PimGento if no label is filled

--- a/Processor/AttributeToFlatArrayProcessor.php
+++ b/Processor/AttributeToFlatArrayProcessor.php
@@ -4,6 +4,7 @@ namespace Pim\Bundle\EnhancedConnectorBundle\Processor;
 
 use Akeneo\Bundle\BatchBundle\Item\AbstractConfigurableStepElement;
 use Akeneo\Bundle\BatchBundle\Item\ItemProcessorInterface;
+use Pim\Bundle\CatalogBundle\Manager\LocaleManager;
 use Pim\Bundle\CatalogBundle\Model\AttributeInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -19,15 +20,20 @@ class AttributeToFlatArrayProcessor extends AbstractConfigurableStepElement impl
     /** @staticvar string */
     const ITEM_SEPARATOR = ',';
 
+    /** @var LocaleManager */
+    protected $localeManager;
+
     /** @var NormalizerInterface */
     protected $transNormalizer;
 
     /**
      * @param NormalizerInterface $transNormalizer
+     * @param LocaleManager       $localeManager
      */
-    public function __construct(NormalizerInterface $transNormalizer)
+    public function __construct(NormalizerInterface $transNormalizer, LocaleManager $localeManager)
     {
         $this->transNormalizer = $transNormalizer;
+        $this->localeManager   = $localeManager;
     }
 
     /**
@@ -35,10 +41,14 @@ class AttributeToFlatArrayProcessor extends AbstractConfigurableStepElement impl
      */
     public function process($attribute)
     {
+        $context = [
+            'locales' => $this->localeManager->getActiveCodes(),
+        ];
+
         $flatAttribute = [
                 'type' => $attribute->getAttributeType(),
                 'code' => $attribute->getCode()
-            ] + $this->transNormalizer->normalize($attribute);
+            ] + $this->transNormalizer->normalize($attribute, null, $context);
 
         $flatAttribute = array_merge(
             $flatAttribute,

--- a/Resources/config/processors.yml
+++ b/Resources/config/processors.yml
@@ -13,3 +13,4 @@ services:
         class: %pim_enhanced_connector.processor.attribute_to_flat_array.class%
         arguments:
             - '@pim_serializer.normalizer.flat.label_translation'
+            - '@pim_catalog.manager.locale'


### PR DESCRIPTION
Attribute labels are tranlated only for active locales
