### PR TITLE
Detaching products in ProductReader is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.2 - (2016-03-08)
+# 1.2.1 - (not released)
+## Improvements
+- Detaching products in ProductReader is deprecated and will be removed in 1.3
+
+# 1.2.0 - (2016-03-08)
 ## New feature
 - Compatibility with Akeneo PIM 1.5
 
@@ -18,7 +22,6 @@
 # 1.0.5 (2016-01-11)
 ## Bug fixes
 - ECB-6: Detach products once processed to avoid memory leak
-
 
 # 1.0.4 (2016-01-07)
 ## New feature

--- a/Reader/ProductReader.php
+++ b/Reader/ProductReader.php
@@ -43,7 +43,10 @@ class ProductReader extends AbstractConfigurableStepElement implements ProductRe
     /** @var EntityManagerInterface */
     protected $entityManager;
 
-    /** @var ObjectDetacherInterface */
+    /** 
+     * @var ObjectDetacherInterface
+     * @deprecated Will be removed in 1.3 
+     */
     protected $objectDetacher;
 
     /** @var bool */
@@ -385,6 +388,7 @@ class ProductReader extends AbstractConfigurableStepElement implements ProductRe
         }
 
         if (null !== $product) {
+            // use of objectDetacher in the reader is deprecated and will be removed in 1.3
             $this->objectDetacher->detach($product);
             $channel = $this->channelManager->getChannelByCode($this->channel);
             $this->metricConverter->convert($product, $channel);


### PR DESCRIPTION
Will be removed in 1.3

The processor can re-attach the product if acessing linked entites like product values.
The detach operation must be done in the processor.
