### PR TITLE
use of object detacher in ProductReader is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.1 - (not released)
 ## Improvements
-- Detaching products in ProductReader is deprecated and will be removed in 1.3
+- Use of object detacher in ProductReader is deprecated and will be removed in 1.3
 
 # 1.2.0 - (2016-03-08)
 ## New feature

--- a/Reader/ProductReader.php
+++ b/Reader/ProductReader.php
@@ -388,8 +388,6 @@ class ProductReader extends AbstractConfigurableStepElement implements ProductRe
         }
 
         if (null !== $product) {
-            // use of objectDetacher in the reader is deprecated and will be removed in 1.3
-            $this->objectDetacher->detach($product);
             $channel = $this->channelManager->getChannelByCode($this->channel);
             $this->metricConverter->convert($product, $channel);
         }


### PR DESCRIPTION
Will be removed in 1.3
