### PR TITLE
Use startTime instead of endTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.2 - (2016-08-04)
+## Improvements
+- Use startTime instead of endTime for last execution date
+
 # 1.2.1 - (2016-06-09)
 ## Improvements
 - Use of object detacher in ProductReader is deprecated and will be removed in 1.3

--- a/Reader/ProductReader.php
+++ b/Reader/ProductReader.php
@@ -496,7 +496,7 @@ class ProductReader extends AbstractConfigurableStepElement implements ProductRe
     {
         $query = $this->entityManager->createQuery(
             sprintf(
-                'SELECT MAX(e.endTime) FROM %s e WHERE e.jobInstance = :jobInstance AND e.exitCode = :completed',
+                'SELECT MAX(e.startTime) FROM %s e WHERE e.jobInstance = :jobInstance AND e.exitCode = :completed',
                 $this->jobExecutionClass
             )
         );


### PR DESCRIPTION
When using `endTime` we may miss products that where created during the last export.

When using `startTime` we may have products that were already exported the last time, but this is not a big problem.
