### PR TITLE
bundle registration reflects new 1.6 AppKernel.php structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,14 @@ Install the bundle with composer:
 Enable the bundle in the `app/AppKernel.php` file:
 
 ```php
-    public function registerBundles()
+    public function registerProjectBundles()
     {
-        $bundles = [
-            new Pim\Bundle\EnhancedConnectorBundle\PimEnhancedConnectorBundle()
-        ]
-
-        // ...
-
-        return $bundles;
+        return [
+            new Pim\Bundle\EnhancedConnectorBundle\PimEnhancedConnectorBundle(),
+            
+            // ...
+            
+        ];
     }
 ```
 


### PR DESCRIPTION
In https://github.com/akeneo/pim-community-standard/commit/0a54d9fdf7a10aeab44c74a33ceffc095d1e8709 structure of the file was slightly changed. This PR brings the readme in line with the current structure introduced in 1.6